### PR TITLE
needed to add import path of cwd

### DIFF
--- a/examples/tracing-client.py
+++ b/examples/tracing-client.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import sys
-
+sys.path.append("")
 from twisted.internet import reactor
 from twisted.web.client import Agent
 from twisted.python import log


### PR DESCRIPTION
Without this I got this error:

<pre>
shai@comp ~/Projects/tryfer <master> python examples/tracing-client.py
Traceback (most recent call last):
  File "examples/tracing-client.py", line 22, in <module>
    from tryfer.tracers import push_tracer, DebugTracer, EndAnnotationTracer
ImportError: No module named tryfer.tracers
</pre>
