### PR TITLE
Fix IP parsing to be consistent with thrift

### DIFF
--- a/tryfer/formatters.py
+++ b/tryfer/formatters.py
@@ -61,8 +61,8 @@ def json_formatter(traces, *json_args, **json_kwargs):
     return json.dumps(json_traces, *json_args, **json_kwargs)
 
 
-def ipv4_to_long(ipv4):
-    return struct.unpack('!L', socket.inet_aton(ipv4))[0]
+def ipv4_to_int(ipv4):
+    return struct.unpack('!i', socket.inet_aton(ipv4))[0]
 
 
 def base64_thrift(thrift_obj):
@@ -102,7 +102,7 @@ def base64_thrift_formatter(trace, annotations):
         host = None
         if annotation.endpoint:
             host = ttypes.Endpoint(
-                ipv4=ipv4_to_long(annotation.endpoint.ipv4),
+                ipv4=ipv4_to_int(annotation.endpoint.ipv4),
                 port=annotation.endpoint.port,
                 service_name=annotation.endpoint.service_name)
 

--- a/tryfer/tests/test_formatters.py
+++ b/tryfer/tests/test_formatters.py
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+
+from twisted.trial.unittest import TestCase
+
+from tryfer import formatters
+
+class TestFormatters(TestCase):
+    def test_ipv4_to_int(self):
+        """ Thrift expects ipv4 address to be a signed 32-bit integer.
+        Previously this function converted ip addresses to an unsigned 32-bit
+        int. struct.pack is strict about integer overflows for signed 32-bit
+        integers, so this function very much needs to produce a signed integer
+        to allow IP addresses in the upper half to work
+        """
+        # ip that doesn't overflow in signed 32-bit
+        low_ip = '127.0.0.1'
+        # ip that does overflow in signed 32-bit
+        high_ip = '172.17.1.1'
+
+        low_ip_as_int = formatters.ipv4_to_int(low_ip)
+        high_ip_as_int = formatters.ipv4_to_int(high_ip)
+
+        # both parsed ips should be packable as signed 32-bit int
+        struct.pack('!i', low_ip_as_int)
+        struct.pack('!i', high_ip_as_int)


### PR DESCRIPTION
Thrift expects IPs to be packable into a signed 32-bit int.  Tryfer
needs to parse IPs into a signed 32-bit int instead of an unsigned int
because struct.pack is strict about packing with integer overflows
